### PR TITLE
Feat: Add chafa support if chafa and file commands are available

### DIFF
--- a/functions/_fzf_preview_file.fish
+++ b/functions/_fzf_preview_file.fish
@@ -18,7 +18,11 @@ function _fzf_preview_file --description "Print a preview for the given file bas
             # need to escape quotes to make sure eval receives file_path as a single arg
             eval "$fzf_preview_file_cmd '$file_path'"
         else
-            bat --style=numbers --color=always "$file_path"
+            if type -q file && type -q chafa && file --mime-type "$file_path" | grep -q image/
+                chafa --size "$FZF_PREVIEW_COLUMNS"'x'"$FZF_PREVIEW_LINES" "$file_path"
+            else
+                bat --style=numbers --color=always "$file_path"
+            end
         end
     else if test -d "$file_path" # directory
         if set --query fzf_preview_dir_cmd


### PR DESCRIPTION
This PR adds checks for chafa and file command being available and using chafa for previewing images.

file command is not available by default in some docker images which is why there is a check for it.